### PR TITLE
test: passing source map json to loader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,6 +52,8 @@ function makeLoader(callback) {
   };
 }
 
+module.exports.parseSourceMap = parseSourceMap;
+
 function parseSourceMap(sourcemap) {
   try {
     return typeof sourcemap === "string" ? JSON.parse(sourcemap) : sourcemap;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -5,6 +5,7 @@ import rimraf from "rimraf";
 import { satisfies } from "semver";
 import webpack from "webpack";
 import createTestDirectory from "./helpers/createTestDirectory";
+import { parseSourceMap } from "../src/index";
 
 const outputDir = path.join(__dirname, "output/loader");
 const babelLoader = path.join(__dirname, "../lib");
@@ -179,5 +180,30 @@ test.cb("should load ESM config files", t => {
     }
     t.deepEqual(stats.compilation.warnings, []);
     t.end();
+  });
+});
+
+// passing source map json to loader
+const sampleSourceMapJson = {
+  version: 3,
+  sources: ["/home/aqua/coding/atri/src/app/app.tsx"],
+  names: [],
+  mappings: ";;;AAAA",
+  sourcesContent: [
+    'ReactDOM.render(, document.body.querySelector("#root"))\\n',
+  ],
+};
+
+const sourceMapJsonTestAssetsPass = [
+  [JSON.stringify(sampleSourceMapJson), sampleSourceMapJson],
+  [undefined, undefined],
+  ["kaljsdfkl", "kaljsdfkl"],
+  [false, false],
+  [{}, {}],
+];
+
+test("passing source map json to loader", t => {
+  sourceMapJsonTestAssetsPass.forEach(([input, expected]) => {
+    t.deepEqual(parseSourceMap(input), expected);
   });
 });


### PR DESCRIPTION
Add some tests to `parseSourceMap` to improve this [Ensure babel understands webpack sourcemaps #889](https://github.com/babel/babel-loader/pull/889)

